### PR TITLE
bent: cmd.Output error may not be ExitError

### DIFF
--- a/bent.go
+++ b/bent.go
@@ -559,9 +559,11 @@ ADD . /
 			}
 			_, err := cmd.Output()
 			if err != nil {
-				ee := err.(*exec.ExitError)
-				s := fmt.Sprintf("There was an error running 'go get', stderr = %s", ee.Stderr)
-				fmt.Println(s + "DISABLING benchmark " + bench.Name)
+				s := fmt.Sprintf("There was an error running 'go get': %v", err)
+				if ee, ok := err.(*exec.ExitError); ok {
+					s += fmt.Sprintf(", stderr = %s", ee.Stderr)
+				}
+				fmt.Println(s + "\nDISABLING benchmark " + bench.Name)
 				getAndBuildFailures = append(getAndBuildFailures, s+"("+bench.Name+")\n")
 				todo.Benchmarks[i].Disabled = true
 				continue


### PR DESCRIPTION
From exec.Cmd.Output: "Any returned error will usually be of type
*ExitError." When the binary cannot be found, the error is actually
*exec.Error.

Allow for non-ExitError rather than panicking.

Before:

( GOMAXPROCS=4 GOPATH=/root/bent/scratch/gopath GOOS=linux GOARCH=arm64 GO111MODULE=auto go get -d -t -v github.com/dr2chase/benchmarks/klauspost )
panic: interface conversion: error is *exec.Error, not *exec.ExitError

goroutine 1 [running]:
main.main()
        /root/bent/bent.go:562 +0x6e8c

After:

( GOMAXPROCS=4 GOPATH=/root/bent/scratch/gopath GOOS=linux GOARCH=arm64 GO111MODULE=auto go get -d -t -v github.com/egonelbre/spexs2/_benchmark )
There was an error running 'go get': exec: "go": executable file not found in $PATH
DISABLING benchmark spexs2
rm -rf /root/bent/scratch/goroots/Tip/
...